### PR TITLE
Support Unix sockets

### DIFF
--- a/tcp_connection.h
+++ b/tcp_connection.h
@@ -60,9 +60,11 @@
 #include <queue>
 #include <mutex>
 #include <condition_variable>
+#if defined(_WIN32)
 #include <winsock2.h>
 #include <windows.h>
 #include <ws2tcpip.h>
+#endif
 #include <string>
 #include <stdlib.h>
 #include <stdio.h>
@@ -213,7 +215,11 @@ namespace tcp_io_device {
     * \param fd The socket file descriptor.
     * \return 1 if data is ready, 0 if no data is ready, -1 for error.
     */
+#if defined(_WIN32)
     static int receiveIsReady(SOCKET fd);
+#else
+    static int receiveIsReady(int fd);
+#endif
 
   protected:
 
@@ -233,8 +239,13 @@ namespace tcp_io_device {
 
     std::shared_ptr<std::thread> tcp_background_thread_;
 
+#if defined(_WIN32)
     SOCKET tcp_socket_;
     SOCKET server_listen_socket_;
+#else
+    int tcp_socket_;
+    int server_listen_socket_;
+#endif
 
     uint64_t msg_buf_size_;
     uint64_t msg_length_buf_size_;

--- a/utils.h
+++ b/utils.h
@@ -273,16 +273,17 @@ namespace tcp_io_device {
     * Setter for the data of the message. Data is stored as a byte representation in form of a std::string.
     * \param d The byte representation of the data in form of a std::string.
     */
-    void setData(std::string d) {
+    void setData(const std::string& d) {
       data_ = d;
     }
 
     template<typename T>
-    void setData(std::vector<T> data) {
+    void setData(const std::vector<T>& data) {
       std::string data_string;
       for (auto it = data.begin(); it != data.end(); ++it) {
         char data_char[sizeof(T)];
-        memcpy(data_char, &(*it), sizeof(T));
+        T value = *it;
+        memcpy(data_char, &value, sizeof(T));
         data_string.append(std::string(data_char, sizeof(T)));
       }
       setData(data_string);

--- a/utils.h
+++ b/utils.h
@@ -288,15 +288,6 @@ namespace tcp_io_device {
       setData(data_string);
     }
 
-    template<>
-    void setData<char>(std::vector<char> data) {
-      std::string data_string;
-      for (auto it = data.begin(); it != data.end(); ++it) {
-        data_string.append(&(*it));
-      }
-      setData(data_string);
-    }
-
     /**
     * Returns the MetaData object corresponding to this MsgData.
     */
@@ -317,13 +308,6 @@ namespace tcp_io_device {
         memcpy(&a, pos, sizeof(T));
         values.push_back(a);
       }
-      return values;
-    }
-
-    template<>
-    std::vector<std::string> getData() {
-      std::vector<std::string> values;
-      values.push_back(data_);
       return values;
     }
 


### PR DESCRIPTION
This PR has 5 commits to add support for Unix sockets. The first four commits make minor fixes and rearrange code to get ready, and the fifth commit adds Unix socket support in the `#else` clause of `#if defined(_WIN32)` . Please see the comment details on the individual commits. Note that our current Unix use case is as a client, so the server code in `listenAndAwaitConnection` (used in Windows Webots) will be updated and tested later.